### PR TITLE
Fix report overflow

### DIFF
--- a/src/main/java/it/sweven/blockcovid/blockchain/documents/PdfReport.java
+++ b/src/main/java/it/sweven/blockcovid/blockchain/documents/PdfReport.java
@@ -1,5 +1,6 @@
 package it.sweven.blockcovid.blockchain.documents;
 
+import com.itextpdf.kernel.geom.PageSize;
 import com.itextpdf.kernel.pdf.PdfDocument;
 import com.itextpdf.kernel.pdf.PdfWriter;
 import com.itextpdf.layout.Document;
@@ -21,6 +22,7 @@ public class PdfReport {
   private LocalDateTime timestamp;
   private @Getter(AccessLevel.PROTECTED) List<Cell> tableHeader;
   private @Getter(AccessLevel.PROTECTED) final ArrayList<List<Cell>> rowsTable;
+  private Boolean landscape = false;
 
   public PdfReport() {
     rowsTable = new ArrayList<>();
@@ -64,6 +66,11 @@ public class PdfReport {
     return this;
   }
 
+  public PdfReport landscape() {
+    this.landscape = true;
+    return this;
+  }
+
   protected Document createNewDocument(String path) throws FileNotFoundException {
     return new Document(new PdfDocument(new PdfWriter(path)));
   }
@@ -90,6 +97,7 @@ public class PdfReport {
 
   public void create(String path) throws BadAttributeValueExpException, FileNotFoundException {
     Document document = createNewDocument(path);
+    if (landscape) document.getPdfDocument().setDefaultPageSize(PageSize.A4.rotate());
     addTitle(document);
     addTimestamp(document);
     addTable(document);

--- a/src/main/java/it/sweven/blockcovid/blockchain/services/DocumentService.java
+++ b/src/main/java/it/sweven/blockcovid/blockchain/services/DocumentService.java
@@ -43,6 +43,7 @@ public class DocumentService {
     String destination = initializeReport(timestamp);
     PdfReport report = createNewReport();
     report
+        .landscape()
         .setTitle("Usage Report")
         .setTimestamp(timestamp)
         .setHeaderTable(

--- a/src/test/java/it/sweven/blockcovid/blockchain/documents/PdfReportTest.java
+++ b/src/test/java/it/sweven/blockcovid/blockchain/documents/PdfReportTest.java
@@ -3,6 +3,7 @@ package it.sweven.blockcovid.blockchain.documents;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.itextpdf.kernel.pdf.PdfDocument;
 import com.itextpdf.layout.Document;
 import com.itextpdf.layout.element.Cell;
 import com.itextpdf.layout.element.IBlockElement;
@@ -114,18 +115,13 @@ public class PdfReportTest {
   void create() throws FileNotFoundException, BadAttributeValueExpException {
     Document mockDocument = mock(Document.class);
     doReturn(mockDocument).when(report).createNewDocument("path");
+    PdfDocument mockPdfDocument = mock(PdfDocument.class);
+    when(mockDocument.getPdfDocument()).thenReturn(mockPdfDocument);
     doNothing().when(report).addTitle(any());
     doNothing().when(report).addTimestamp(any());
     doNothing().when(report).addTable(any());
-    AtomicBoolean closeCalled = new AtomicBoolean(false);
-    doAnswer(
-            invocation -> {
-              closeCalled.set(true);
-              return null;
-            })
-        .when(mockDocument)
-        .close();
-    report.create("path");
-    assertTrue(closeCalled.get());
+    report.landscape().create("path");
+    verify(mockDocument).close();
+    verify(mockPdfDocument).setDefaultPageSize(any());
   }
 }

--- a/src/test/java/it/sweven/blockcovid/blockchain/services/DocumentServiceTest.java
+++ b/src/test/java/it/sweven/blockcovid/blockchain/services/DocumentServiceTest.java
@@ -114,6 +114,7 @@ class DocumentServiceTest {
                 false);
     PdfReport mockReport = mock(PdfReport.class);
     doReturn(mockReport).when(service).createNewReport();
+    when(mockReport.landscape()).thenReturn(mockReport);
     when(mockReport.setTitle(any())).thenReturn(mockReport);
     when(mockReport.setTimestamp(any())).thenReturn(mockReport);
     when(mockReport.setHeaderTable(any())).thenReturn(mockReport);
@@ -154,6 +155,7 @@ class DocumentServiceTest {
                 false);
     PdfReport mockReport = mock(PdfReport.class);
     doReturn(mockReport).when(service).createNewReport();
+    when(mockReport.landscape()).thenReturn(mockReport);
     when(mockReport.setTitle(any())).thenReturn(mockReport);
     when(mockReport.setTimestamp(any())).thenReturn(mockReport);
     when(mockReport.setHeaderTable(any())).thenReturn(mockReport);


### PR DESCRIPTION
Fixed usage reports' entries overflowing by rotating the report

[before.pdf](https://github.com/SwevenSoftware/BlockCOVID-server/files/6395081/before.pdf)
[after.pdf](https://github.com/SwevenSoftware/BlockCOVID-server/files/6395082/after.pdf)