### PR TITLE
Fix login errors when username not found

### DIFF
--- a/src/main/java/it/sweven/blockcovid/users/controllers/LoginController.java
+++ b/src/main/java/it/sweven/blockcovid/users/controllers/LoginController.java
@@ -63,7 +63,7 @@ public class LoginController implements AccountController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, exception.getMessage());
     } catch (UsernameNotFoundException exception) {
       logger.warn("Username " + credentials.getUsername() + " not found");
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, exception.getMessage());
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, exception.getMessage());
     }
   }
 }

--- a/src/main/java/it/sweven/blockcovid/users/controllers/LoginController.java
+++ b/src/main/java/it/sweven/blockcovid/users/controllers/LoginController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -60,6 +61,9 @@ public class LoginController implements AccountController {
     } catch (BadCredentialsException exception) {
       logger.warn("invalid credentials supplied for user " + credentials.getUsername());
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, exception.getMessage());
+    } catch (UsernameNotFoundException exception) {
+      logger.warn("Username " + credentials.getUsername() + " not found");
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, exception.getMessage());
     }
   }
 }

--- a/src/test/java/it/sweven/blockcovid/users/controllers/LoginControllerTest.java
+++ b/src/test/java/it/sweven/blockcovid/users/controllers/LoginControllerTest.java
@@ -65,6 +65,6 @@ class LoginControllerTest {
         assertThrows(
             ResponseStatusException.class,
             () -> controller.login(new Credentials("user", "password")));
-    assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
+    assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
   }
 }

--- a/src/test/java/it/sweven/blockcovid/users/controllers/LoginControllerTest.java
+++ b/src/test/java/it/sweven/blockcovid/users/controllers/LoginControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.server.ResponseStatusException;
 
 class LoginControllerTest {
@@ -55,5 +56,15 @@ class LoginControllerTest {
             ResponseStatusException.class,
             () -> controller.login(new Credentials("user", "password")));
     assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatus());
+  }
+
+  @Test
+  void username_not_found() {
+    when(service.login(any(), any())).thenThrow(new UsernameNotFoundException(""));
+    ResponseStatusException thrown =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> controller.login(new Credentials("user", "password")));
+    assertEquals(HttpStatus.NOT_FOUND, thrown.getStatus());
   }
 }


### PR DESCRIPTION
the login service might throw `UsernameNotFoundException`, which was not properly handled until now